### PR TITLE
Replace forward slashes encoded by Jenkins in the workspace path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ## ws-ws-replacement 
-Workspace Whitespace Replacement is a simple Jenkins plug-in that allows job to be created with spaces in their name, but when the job is carried out on a slave node, the path used will have all spaces replaced by an underscore.
+Workspace Whitespace Replacement is a simple Jenkins plug-in that allows job to be created with spaces in their name, but when the job is carried out on a slave node, the path used will have all spaces and encoded forward slashes replaced by an underscore.
 
 Out of the box, Jenkins offers a couple of ways to limit or restrict characters such as spaces in workspace paths that are not ideal in a number of situations
 - Restrict Project Naming - inconvenient because it removes the ability to have spaces in job names, making them harder to read, especially if you have a large number of them
 - Custom Workspaces - inconvenient because the requirement for uniqueness is on the user, and it requires much more thought when creating projects if you have a high number of them
 
-The Whitespace Replacement plug-in still allows the Job name to be the unique identifer for the project, keeps them easy to read and requires no additional work to create job paths that will work with scripts or processes that cannot handle spaces in path names.
+The Whitespace Replacement plug-in still allows the Job name to be the unique identifer for the project, keeps them easy to read and requires no additional work to create job paths that will work with scripts or processes that cannot handle spaces in path names. In the case of a multi branch pipeline, it could happen that a branch contains a forward slash in it's name, especially when using GitFlow. This character will be encoded by Jenkins and could potentially break some tools handled by different plugins, for example Maven. To overcome this limitation, `%2F` will also be replaced by an underscore.
 
 
 ### Current Build Status

--- a/src/main/java/org/jenkinsci/plugins/wswsreplacement/WsWsReplacement.java
+++ b/src/main/java/org/jenkinsci/plugins/wswsreplacement/WsWsReplacement.java
@@ -60,7 +60,7 @@ public class WsWsReplacement extends WorkspaceLocator
     private FilePath getWorkSpacePath(Slave slave, TopLevelItem item)
     {
         // Replace the spaces in the job name with underscores
-        String jobName = item.getFullName().replaceAll("\\s","_");
+        String jobName = item.getFullName().replaceAll("\\s","_").replace("%2F","_");
 
         // Get the full path for this job on the slave
         FilePath pathToUse = buildCompletePath(jobName, slave);

--- a/src/test/java/org/jenkinsci/plugins/wswsreplacement/WsWsReplacementTest.java
+++ b/src/test/java/org/jenkinsci/plugins/wswsreplacement/WsWsReplacementTest.java
@@ -128,6 +128,34 @@ public class WsWsReplacementTest
                     equalTo(expectedPath));
     }
 
+    @Test
+    public void freeStyleProjectReplacesEncoding() throws Exception
+    {
+        // Get a slave to test against
+        DumbSlave dumbSlave = JenkinsRule.createOnlineSlave();
+
+        String actualPath = createProjectAndGetPath(dumbSlave, "Project%2FWith%2FSlash");
+        String expectedPath = dumbSlave.getRootPath() + "/workspace/Project_With_Slash";
+
+        // Check the path has been updated correctly
+        assertThat( actualPath,
+                    equalTo(expectedPath));
+    }
+
+    @Test
+    public void freeStyleProjectReplacesSpacesAndEncoding() throws Exception
+    {
+        // Get a slave to test against
+        DumbSlave dumbSlave = JenkinsRule.createOnlineSlave();
+
+        String actualPath = createProjectAndGetPath(dumbSlave, "Project%2FWith%2FSlash And Space");
+        String expectedPath = dumbSlave.getRootPath() + "/workspace/Project_With_Slash_And_Space";
+
+        // Check the path has been updated correctly
+        assertThat( actualPath,
+                    equalTo(expectedPath));
+    }
+
     //
     // Returns the path of the creates project
     //


### PR DESCRIPTION
In the case of a Multibranch pipeline, it could happen that a branch contains a forward slash in it's name, especially when using GitFlow. This character will be encoded by Jenkins and could potentially break some tools handled by different plugins, for example Maven.
To overcome this limitation, we'd like to replace `%2F` by an underscore.
We were using this plugin to solve issues created by spaces in the workspace path, we thought it could be a nice place to add this functionality that would solve the problems created by the encoding in the path as well.